### PR TITLE
feat: Implement teacher control over student translations

### DIFF
--- a/polycast-frontend/src/components/Controls.jsx
+++ b/polycast-frontend/src/components/Controls.jsx
@@ -22,6 +22,7 @@ function Controls({
     setShowLiveTranscript,
     showTranslation,
     setShowTranslation,
+    teacherTranslationsEnabled, // Added new prop
     translationLockedByHost = false,
     isStudentMode = false,
     selectedProfile,
@@ -32,6 +33,7 @@ function Controls({
     // Check if we're in host mode (all control functions available) or student mode (view-only)
     const isHostMode = setIsTextMode !== null && onStartRecording !== null;
     const isConnected = readyState === ReadyState.OPEN;
+    const isTranslationsDisabledByTeacher = isStudentMode && !teacherTranslationsEnabled;
 
     return (
         <div className="controls">
@@ -84,13 +86,18 @@ function Controls({
                     <label style={{ display: 'flex', alignItems: 'center', gap: 4, marginLeft: 14, fontSize: 15, fontWeight: 500, color: '#ccc' }}>
                       <input
                         type="checkbox"
-                        checked={showTranslation}
+                        checked={isTranslationsDisabledByTeacher ? false : showTranslation}
                         onChange={e => {
                           setShowTranslation && setShowTranslation(e.target.checked);
                         }}
-                        disabled={isRecording}
+                        disabled={isRecording || isTranslationsDisabledByTeacher}
                       />
                       Show Translation
+                      {isTranslationsDisabledByTeacher && (
+                        <span style={{ marginLeft: '8px', color: '#ffcc00', fontSize: '0.9em' }}>
+                          (Translations disabled by teacher)
+                        </span>
+                      )}
                     </label>
                     <label style={{ display: 'flex', alignItems: 'center', gap: 4, marginLeft: 14, fontSize: 15, fontWeight: 500, color: '#ccc' }}>
                       <input
@@ -201,6 +208,7 @@ Controls.propTypes = {
     setShowLiveTranscript: PropTypes.func,
     showTranslation: PropTypes.bool.isRequired,
     setShowTranslation: PropTypes.func,
+    teacherTranslationsEnabled: PropTypes.bool, // Added prop type
     selectedProfile: PropTypes.string.isRequired,
     setSelectedProfile: PropTypes.func.isRequired,
 };


### PR DESCRIPTION
This commit introduces functionality allowing teachers (hosts) to enable or disable translations for all students in a room.

Key changes:

Backend (`server.js`):
- Added a `translationsEnabled` flag to room data (default: true), persisted in Redis.
- Introduced `TOGGLE_ROOM_TRANSLATIONS` WebSocket message for hosts to change this flag.
- Implemented `ROOM_TRANSLATIONS_STATUS` broadcast to inform students of the current state.
- Students now receive the room's translation status upon joining.

Frontend (`App.jsx`):
- Added `teacherTranslationsEnabled` state, updated via `ROOM_TRANSLATIONS_STATUS` message.
- Logic modified to hide translations for students if `teacherTranslationsEnabled` is false, overriding local student preference.
- Hosts now send `TOGGLE_ROOM_TRANSLATIONS` to the backend when they toggle their own "Show Translation" checkbox.

Frontend (`Controls.jsx`):
- Students' "Show Translation" checkbox is now disabled and visually unchecked if the teacher has disabled translations.
- A message "Translations disabled by teacher" is displayed to students in this state.

Testing:
- I performed manual test scenarios to verify functionality, including initial states, teacher toggling, student joining states, and persistence of your local preference.