### PR TITLE
feat: Implement two-step Gemini prompts for flashcard generation

### DIFF
--- a/polycast-frontend/src/components/DictionaryTable.jsx
+++ b/polycast-frontend/src/components/DictionaryTable.jsx
@@ -188,9 +188,10 @@ const DictionaryTable = ({ wordDefinitions, onRemoveWord }) => {
   const getWordFrequency = (word) => {
     const entries = groupedEntries[word] || [];
     const firstEntry = entries[0] || {};
-    const frequency = firstEntry?.disambiguatedDefinition?.wordFrequency || null;
+    // Access wordFrequency directly from the first entry
+    const frequency = firstEntry?.wordFrequency || null; 
     
-    if (!frequency) {
+    if (frequency === null || typeof frequency === 'undefined') {
       // Generate a consistent frequency rating if none available
       const sum = word.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0);
       return (sum % 5) + 1;
@@ -539,40 +540,39 @@ const DictionaryTable = ({ wordDefinitions, onRemoveWord }) => {
                             <div className="part-of-speech">{partOfSpeech}</div>
                             {/* Usage frequency for this specific definition */}
                             {(() => {
-                              const usageFrequency = entry?.disambiguatedDefinition?.definitions?.[0]?.usageFrequency || 
-                                                   entry?.disambiguatedDefinition?.usageFrequency;
+                              const usageFrequencyValue = entry?.definitionFrequency ||
+                                                       entry?.disambiguatedDefinition?.definitionFrequency ||
+                                                       null;
+                              const usageFrequency = usageFrequencyValue ? parseInt(usageFrequencyValue, 10) : 3; // Default to 3 if null
                               
-                              if (usageFrequency) {
-                                // Get a text description of the frequency
-                                const frequencyText = {
-                                  1: 'Very Rare Usage',
-                                  2: 'Uncommon Usage',
-                                  3: 'Secondary Usage',
-                                  4: 'Common Usage',
-                                  5: 'Primary Usage'
-                                }[parseInt(usageFrequency, 10)] || '';
+                              // Get a text description of the frequency
+                              const frequencyText = {
+                                1: 'Very Rare Usage',
+                                2: 'Uncommon Usage',
+                                3: 'Secondary Usage',
+                                4: 'Common Usage',
+                                5: 'Primary Usage'
+                              }[usageFrequency] || '';
                                 
-                                return (
-                                  <div className="usage-frequency" style={{ 
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    marginLeft: '12px',
-                                    backgroundColor: 'rgba(0, 0, 0, 0.2)',
-                                    padding: '4px 10px',
-                                    borderRadius: '12px',
-                                    gap: '8px'
-                                  }}>
-                                    <span style={{ color: '#f5f5f5', fontSize: '13px', fontWeight: 'bold' }}>
-                                      Definition Frequency: 
-                                    </span>
-                                    <FrequencyDots frequency={parseInt(usageFrequency, 10)} size={8} showValue={false} />
-                                    <span style={{ color: '#a0a0b8', fontSize: '13px' }}>
-                                      {frequencyText}
-                                    </span>
-                                  </div>
-                                );
-                              }
-                              return null;
+                              return (
+                                <div className="usage-frequency" style={{ 
+                                  display: 'flex',
+                                  alignItems: 'center',
+                                  marginLeft: '12px',
+                                  backgroundColor: 'rgba(0, 0, 0, 0.2)',
+                                  padding: '4px 10px',
+                                  borderRadius: '12px',
+                                  gap: '8px'
+                                }}>
+                                  <span style={{ color: '#f5f5f5', fontSize: '13px', fontWeight: 'bold' }}>
+                                    Definition Frequency: 
+                                  </span>
+                                  <FrequencyDots frequency={usageFrequency} size={8} showValue={false} />
+                                  <span style={{ color: '#a0a0b8', fontSize: '13px' }}>
+                                    {frequencyText}
+                                  </span>
+                                </div>
+                              );
                             })()}
                           </div>
                           {onRemoveWord && (

--- a/polycast-frontend/src/components/TranscriptionDisplay.jsx
+++ b/polycast-frontend/src/components/TranscriptionDisplay.jsx
@@ -185,6 +185,9 @@ const TranscriptionDisplay = ({
     console.log('📋 SELECTED WORDS COUNT:', selectedWords.length);
     
     const wordLower = word.toLowerCase();
+    let examples = [];
+    let wordFrequency = 3;
+    let definitionFrequency = 3;
     
     // Calculate position for popup
     const rect = event.currentTarget.getBoundingClientRect();
@@ -304,15 +307,9 @@ const TranscriptionDisplay = ({
           disambiguatedDefinition = disambiguationResponse.disambiguatedDefinition;
           
           // Extract the examples and frequency ratings from the two-step process
-          if (disambiguationResponse.examples && Array.isArray(disambiguationResponse.examples)) {
-            examples = disambiguationResponse.examples;
-          }
-          if (typeof disambiguationResponse.wordFrequency === 'number') {
-            wordFrequency = disambiguationResponse.wordFrequency;
-          }
-          if (typeof disambiguationResponse.definitionFrequency === 'number') {
-            definitionFrequency = disambiguationResponse.definitionFrequency;
-          }
+          examples = disambiguationResponse.examples || [];
+          wordFrequency = disambiguationResponse.wordFrequency || 3;
+          definitionFrequency = disambiguationResponse.definitionFrequency || 3;
           
           // Log the status of our new fields
           console.log('FLASHCARD DEBUG - Received from disambiguation:', {
@@ -331,11 +328,6 @@ const TranscriptionDisplay = ({
         disambiguatedDefinition = dictData.allDefinitions[0];
       }
       
-      // Default values for the two-step process fields
-      let examples = [];
-      let wordFrequency = 3;
-      let definitionFrequency = 3;
-      
       // Update the wordDefinitions state with all the data
       setWordDefinitions(prev => ({
         ...prev,
@@ -345,7 +337,7 @@ const TranscriptionDisplay = ({
           disambiguatedDefinition: disambiguatedDefinition, // The most relevant definition
           contextSentence: contextSentence, // Save the context for flashcards
           // Store the new fields from our two-step process
-          examples: examples,
+          exampleSentencesRaw: examples.join('//'),
           wordFrequency: wordFrequency,
           definitionFrequency: definitionFrequency
         }


### PR DESCRIPTION
I've integrated a two-step Gemini prompting process for enhanced flashcard creation and dictionary information.

1.  **Disambiguation & Definition (First Prompt):**
    - When you click a word, the frontend now ensures that the `/api/disambiguate-word` endpoint in the backend is utilized.
    - This endpoint takes the word, context, and possible definitions. Its first LLM call determines the most relevant definition and its translation in context.
    - The `WordDefinitionPopup.jsx` displays this contextual definition and translation.

2.  **Example Sentences & Frequencies (Second Prompt):**
    - The `/api/disambiguate-word` backend endpoint automatically triggers a second LLM call.
    - This second prompt generates three example sentences using the word in its disambiguated context, a general word frequency rating (1-5), and a definition-specific frequency rating (1-5).
    - `TranscriptionDisplay.jsx` has been updated to correctly parse and store all these fields (`exampleSentencesRaw`, `wordFrequency`, `definitionFrequency`) into the `wordDefinitions` state.
    - `FlashcardMode.jsx` now displays the three example sentences on the flashcard back, using the populated `exampleSentencesRaw` field.
    - `DictionaryTable.jsx` now uses the fetched `wordFrequency` and `definitionFrequency` from the state, replacing the previous random generation for these values.

This change aligns flashcard and dictionary features with the requested multi-prompt LLM interaction, providing richer and more accurate learning content for you.