### PR TITLE
Refactor frontend into modular components

### DIFF
--- a/polycast-frontend/dictionary-popup.ts
+++ b/polycast-frontend/dictionary-popup.ts
@@ -1,0 +1,97 @@
+import { LitElement, html, css } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import type { WordPopupData } from './types.js';
+
+@customElement('dictionary-popup')
+export class DictionaryPopup extends LitElement {
+  @property({ attribute: false }) popupData: WordPopupData | null = null;
+  @property({ type: Boolean }) loading = false;
+  @property({ type: String }) error: string | null = null;
+  @property({ type: Boolean }) inDictionary = false;
+  @property() nativeLanguage = '';
+  @property() targetLanguage = '';
+  @property({ type: Boolean }) disableToggle = false;
+
+  static styles = css`
+    .popup-overlay {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100vw;
+      height: 100vh;
+      background: transparent;
+      z-index: 999;
+    }
+    .word-popup {
+      position: fixed;
+      background-color: #2a2139;
+      border: 1px solid #3c3152;
+      border-radius: 8px;
+      padding: 15px 20px;
+      z-index: 1000;
+      min-width: 250px;
+      max-width: 380px;
+      box-shadow: 0 5px 15px rgba(0,0,0,0.2);
+      color: #e0e0e0;
+      font-size: 14px;
+      line-height: 1.5;
+      transform: translateX(-50%);
+    }
+    .dictionary-toggle-btn {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 24px;
+      height: 24px;
+      border-radius: 50%;
+      border: none;
+      cursor: pointer;
+      background-color: #4a3f63;
+      color: #e0e0e0;
+    }
+    .dictionary-toggle-btn.added {
+      background-color: #3cb371;
+      color: #ffffff;
+    }
+    .popup-close-btn {
+      position: absolute;
+      top: 10px;
+      right: 12px;
+      background: none;
+      border: none;
+      color: #bca0dc;
+      font-size: 1.6em;
+      font-weight: bold;
+      cursor: pointer;
+      padding: 0;
+      line-height: 1;
+    }
+  `;
+
+  private onToggle() {
+    if (!this.popupData) return;
+    this.dispatchEvent(new CustomEvent('toggle-dictionary', {
+      detail: this.popupData,
+      bubbles: true,
+      composed: true,
+    }));
+  }
+
+  render() {
+    if (!this.popupData) return html``;
+    return html`
+      <div class="popup-overlay" @click=${() => this.dispatchEvent(new CustomEvent('close-popup', { bubbles: true, composed: true }))} role="presentation"></div>
+      <div class="word-popup" style="top:${this.popupData.y}px; left:${this.popupData.x}px;" role="dialog">
+        <button @click=${() => this.dispatchEvent(new CustomEvent('close-popup', { bubbles: true, composed: true }))} class="popup-close-btn" aria-label="Close">&times;</button>
+        <div class="word-popup-header">
+          <span class="popup-selected-word">${this.popupData.displayWord || this.popupData.word}</span>
+          <button class="dictionary-toggle-btn ${this.inDictionary ? 'added' : ''}" @click=${this.onToggle} ?disabled=${this.disableToggle} title="Toggle dictionary">${this.inDictionary ? '✓' : '+'}</button>
+        </div>
+        ${this.loading ? html`<p>Loading details...</p>` : this.error ? html`<p>${this.error}</p>` : html`
+          ${this.popupData.translation ? html`<div><span class="popup-label">Translation (to ${this.nativeLanguage})</span><span class="popup-content-text">${this.popupData.translation}</span></div>` : ''}
+          ${this.popupData.definition ? html`<div><span class="popup-label">Definition (in ${this.nativeLanguage})</span><span class="popup-content-text">${this.popupData.definition}</span></div>` : ''}
+        `}
+      </div>
+    `;
+  }
+}

--- a/polycast-frontend/flashcard-manager.ts
+++ b/polycast-frontend/flashcard-manager.ts
@@ -1,0 +1,91 @@
+import { LitElement, html, css } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import type { Flashcard } from './types.js';
+
+@customElement('flashcard-manager')
+export class FlashcardManager extends LitElement {
+  @property({ attribute: false }) flashcards: Flashcard[] = [];
+  @property({ attribute: false }) flashcardQueue: string[] = [];
+  @property({ type: Number }) currentIndex = 0;
+  @property({ attribute: false }) flipState: Map<string, boolean> = new Map();
+  @property({ attribute: false }) intervals: Map<string, number> = new Map();
+  @property({ type: String }) targetLanguage = '';
+
+  static styles = css`
+    .flashcards-content {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      color: #8a80a5;
+      font-size: 1.1em;
+    }
+    .flashcard-viewer {
+      perspective: 1000px;
+    }
+    .flashcard-container {
+      width: 340px;
+      height: 200px;
+      transition: transform 0.6s;
+      transform-style: preserve-3d;
+      position: relative;
+    }
+    .flashcard-container.flipped {
+      transform: rotateY(180deg);
+    }
+    .flashcard {
+      position: absolute;
+      width: 100%;
+      height: 100%;
+      backface-visibility: hidden;
+      border-radius: 8px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 20px;
+      box-sizing: border-box;
+      background-color: #3c3152;
+      color: #e0e0e0;
+    }
+    .card-back {
+      transform: rotateY(180deg);
+    }
+  `;
+
+  private flip(cardId: string) {
+    const state = this.flipState.get(cardId) ?? false;
+    this.flipState.set(cardId, !state);
+    this.requestUpdate();
+  }
+
+  render() {
+    const currentId = this.flashcardQueue[this.currentIndex];
+    const card = this.flashcards.find(fc => fc.id === currentId);
+    const flipped = currentId ? this.flipState.get(currentId) === true : false;
+    return html`
+      <div class="flashcards-content">
+        ${!card ? html`<p class="no-flashcards-message">No cards</p>` : html`
+          <div class="flashcard-viewer" @click=${() => currentId && this.flip(currentId)}>
+            <div class="flashcard-container ${flipped ? 'flipped' : ''}">
+              <div class="flashcard card-front">
+                ${card.exampleSentences[0]?.english || ''}
+              </div>
+              <div class="flashcard card-back">
+                ${card.exampleSentences[0]?.portugueseTranslation || ''}
+              </div>
+            </div>
+          </div>
+          <div class="flashcard-nav">
+            <button @click=${() => this.dispatchEvent(new CustomEvent('prev-card', { bubbles: true, composed: true }))}>◄</button>
+            <span class="card-count">${this.currentIndex + 1}/${this.flashcardQueue.length}</span>
+            <button @click=${() => this.dispatchEvent(new CustomEvent('next-card', { bubbles: true, composed: true }))}>►</button>
+          </div>
+          <div class="flashcard-actions">
+            <button @click=${() => this.dispatchEvent(new CustomEvent('answer-card', { detail: { correct: false }, bubbles: true, composed: true }))}>Incorrect</button>
+            <button @click=${() => this.dispatchEvent(new CustomEvent('answer-card', { detail: { correct: true }, bubbles: true, composed: true }))}>Correct</button>
+          </div>
+        `}
+      </div>
+    `;
+  }
+}

--- a/polycast-frontend/gemini-api-service.ts
+++ b/polycast-frontend/gemini-api-service.ts
@@ -4,7 +4,7 @@
  */
 
 import { GoogleGenAI, GenerateContentResponse } from '@google/genai';
-import type { FlashcardExampleSentence, EvaluationData, TranscriptMessage } from './index.js'; // Fixed import extension
+import type { FlashcardExampleSentence, EvaluationData, TranscriptMessage } from './types.js';
 
 const MODEL_NAME = 'gemini-2.5-flash-preview-04-17';
 

--- a/polycast-frontend/transcript-viewer.ts
+++ b/polycast-frontend/transcript-viewer.ts
@@ -1,0 +1,85 @@
+import { LitElement, html, css } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import type { TranscriptMessage } from './types.js';
+
+@customElement('transcript-viewer')
+export class TranscriptViewer extends LitElement {
+  @property({ attribute: false }) transcriptHistory: TranscriptMessage[] = [];
+  @property({ type: Number }) transcriptFontSize = 26;
+  @property({ attribute: false }) knownWordForms: Set<string> = new Set();
+
+  static styles = css`
+    .transcript-messages-container {
+      flex-grow: 1;
+      overflow-y: auto;
+      padding: 20px;
+    }
+    .transcript-messages {
+      display: flex;
+      flex-direction: column;
+      gap: 0px;
+    }
+    .transcript-message {
+      background-color: #3c3152;
+      padding: 8px 12px;
+      line-height: 1.5;
+      color: #e0e0e0;
+      word-wrap: break-word;
+      margin-top: 0;
+      margin-bottom: 0;
+      border-radius: 10px;
+    }
+    .transcript-message.user {
+      background-color: #34495e;
+      color: #ecf0f1;
+    }
+    .clickable-word {
+      cursor: pointer;
+      text-decoration: underline;
+      text-decoration-color: #a093c4;
+      text-decoration-thickness: 1px;
+      text-underline-offset: 3px;
+      padding-bottom: 1px;
+    }
+    .clickable-word.known-word {
+      color: #60a5fa;
+      text-decoration-color: #93c5fd;
+    }
+  `;
+
+  private renderMessage(text: string) {
+    const tokens = text.split(/(\s+)/);
+    return tokens.map(token => {
+      if (token.trim() === '') return token;
+      const key = token.replace(/[.,!?;:()"']/g, '').toLowerCase();
+      const known = this.knownWordForms.has(key);
+      return html`<span
+        class="clickable-word ${known ? 'known-word' : ''}"
+        @click=${(e: MouseEvent) => {
+          this.dispatchEvent(new CustomEvent('word-click', {
+            detail: { word: token, sentence: text, event: e },
+            bubbles: true,
+            composed: true,
+          }));
+        }}>
+          ${token}
+        </span>`;
+    });
+  }
+
+  render() {
+    return html`
+      <div class="transcript-messages-container">
+        <div class="transcript-messages">
+          ${this.transcriptHistory.map((msg, index, arr) => html`
+            <p
+              class="transcript-message ${msg.speaker === 'user' ? 'user' : ''} ${index === arr.length - 1 ? 'latest' : ''}"
+              style="font-size: ${this.transcriptFontSize}px;"
+              data-speaker=${msg.speaker}
+            >${this.renderMessage(msg.text)}</p>
+          `)}
+        </div>
+      </div>
+    `;
+  }
+}

--- a/polycast-frontend/types.ts
+++ b/polycast-frontend/types.ts
@@ -1,0 +1,59 @@
+export interface WordPopupData {
+  word: string;
+  sentence: string;
+  translation: string;
+  definition: string;
+  partOfSpeech: string;
+  lemmatizedWord?: string;
+  displayWord?: string;
+  x: number;
+  y: number;
+  targetWidth: number;
+}
+
+export interface TranscriptMessage {
+  speaker: 'user' | 'model' | 'partner';
+  text: string;
+  id: string;
+}
+
+export interface DictionaryEntry {
+  word: string;
+  translation: string;
+  definition: string;
+  partOfSpeech: string;
+  sentenceContext: string;
+  frequency: number | null;
+  rank: number | null;
+  dateAdded: number;
+}
+
+export interface FlashcardExampleSentence {
+  english: string;
+  portugueseTranslation: string;
+}
+
+export interface Flashcard {
+  id: string;
+  originalWordKey: string;
+  dictionaryEntry: DictionaryEntry;
+  exampleSentences: FlashcardExampleSentence[];
+  status: 'new' | 'learning' | 'review';
+  correctCount: number;
+  incorrectCount: number;
+  interval: number;
+  easeFactor: number;
+  dueDate: number;
+  lastReviewed: number;
+  learningStep: number;
+}
+
+export interface EvaluationSuggestion {
+  category: string;
+  description: string;
+}
+
+export interface EvaluationData {
+  improvementAreas: EvaluationSuggestion[];
+  cefrLevel: string;
+}


### PR DESCRIPTION
## Summary
- split frontend interfaces into `types.ts`
- add `transcript-viewer`, `dictionary-popup` and `flashcard-manager` Lit components
- refactor `index.tsx` to use new components
- update imports in `gemini-api-service.ts`

## Testing
- `node polycast-backend/direct-db-test.js` *(fails: Cannot find package 'pg')*
- `git count-objects -vH`
- `git ls-files | xargs ls -la | awk '$5 > 1000000'`

------
https://chatgpt.com/codex/tasks/task_e_684a135d60f48327b8ebb49ebd1640fb